### PR TITLE
Add Blog URL setting and add setting descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # HCPSS School Site Configuration
 
-This is a simple Drupal module to house some configuration setting that are used
-throughout HCPSS School Sites.
+This is a simple Drupal module to house configuration settings that are used
+throughout HCPSS school sites.  The module adds custom settings on the site
+information form (https://example.com/admin/config/system/site-information).
 
-It adds "School Code" and "Facebook URL" settings to the site information form 
-for example https://example.com/admin/config/system/site-information. School code 
-is set to an initial value that it guesses from the database name, but it can be 
-changed on the form.
+The following are a list of custom settings and their relevant notes:
+
+**School Code** - While set to an initial value that it guesses from the
+database name, the value can be overridden via the form.  This setting is used
+for Twitter profiles and site search collections.
+
+**Facebook URL** - The value should include the full https URL of the school's
+Facebook page.
+
+**Blog URL** - The value should include the full URL of the school's blog.

--- a/hcpss_schoolsite_config.info
+++ b/hcpss_schoolsite_config.info
@@ -2,4 +2,4 @@ name = HCPSS School Site Configuration
 description = Common configuration settings for HCPSS School Sites
 core = 7.x
 package = HCPSS
-version = "7.x-1.0"
+version = "7.x-1.1"

--- a/hcpss_schoolsite_config.module
+++ b/hcpss_schoolsite_config.module
@@ -6,9 +6,9 @@
 
 /**
  * Implementation of hook_form_FORM_ID_alter
- * 
+ *
  * Add our configuration to the site information form.
- * 
+ *
  * @param array $form
  * @param array $form_state
  * @param string $form_id
@@ -18,27 +18,38 @@ function hcpss_schoolsite_config_form_system_site_information_settings_alter(&$f
     '#type'   => 'fieldset',
     '#title'  => 'HCPSS Schools Site Configuration',
   );
-  
+
   // Add the school code field
   $form['hcpss_schoolsite_config']['hcpss_school_code'] = array(
     '#type'           => 'textfield',
     '#title'          => 'School Code',
+    '#description'    => t('The school abbreviation used for subdomain and other naming access.'),
     '#default_value'  => variable_get('hcpss_school_code'),
     '#required'       => TRUE,
   );
-  
+
   // Add the facebook URL field
   $form['hcpss_schoolsite_config']['hcpss_school_facebook_url'] = array(
     '#type'             => 'textfield',
     '#title'            => 'Facebook URL',
+    '#description'      => t("The full URL of the school's Facebook page."),
     '#default_value'    => variable_get('hcpss_school_facebook_url'),
+    '#element_validate' => array('_hcpss_schoolsite_config_validate_url'),
+  );
+
+  // Add the blog URL field
+  $form['hcpss_schoolsite_config']['hcpss_school_blog_url'] = array(
+    '#type'             => 'textfield',
+    '#title'            => 'Blog URL',
+    '#description'      => t("The full URL of the school's blog"),
+    '#default_value'    => variable_get('hcpss_school_blog_url'),
     '#element_validate' => array('_hcpss_schoolsite_config_validate_url'),
   );
 }
 
 /**
  * Element validate callback to validate that an element is a valid URL.
- * 
+ *
  * @param array $element
  * @param array $form_state
  * @param array $form
@@ -62,17 +73,17 @@ function _hcpss_schoolsite_config_set_default_config() {
 
 /**
  * Guess the school code from the name of the database
- * 
+ *
  * @global array $databases
  * @return string
  */
 function _hcpss_schoolsite_config_guess_school_code() {
   global $databases;
-  
+
   // If the database name is "site_hs_rhhs" then the code is "rhhs"
   $db_name        = $databases['default']['default']['database'];
   $db_name_array  = explode('_', $db_name);
   $code           = array_pop($db_name_array);
-  
+
   return $code;
 }


### PR DESCRIPTION
Add a custom Blog URL setting to hold the link of the school's blog. Add
descriptions for the School Code and Facebook URL settings. Lastly, document the
new custom setting and increment the module's version number.
